### PR TITLE
Upgrade Django 3 compatibility

### DIFF
--- a/basic_models/actions.py
+++ b/basic_models/actions.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from django.utils.translation import ugettext_lazy as _lazy, ugettext as _
+from django.utils.translation import gettext_lazy as _lazy, gettext as _
 from django.contrib.admin.utils import model_ngettext as model_verbose_name
 
 

--- a/basic_models/version.py
+++ b/basic_models/version.py
@@ -1,1 +1,1 @@
-VERSION = (4,0,1)
+VERSION = (4,0,2)


### PR DESCRIPTION
## Description

In Django 4 were removed already deprecated methods like

1. uggettext() was replaced with gettext()

So it makes sense to update packages in order to fit our project